### PR TITLE
clear frame after last turnin

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -177,6 +177,8 @@ class Controller:
             while not self.massacre_frame:
                 pass
             self.massacre_frame.update_data(massacre_data)
+        else:
+            self.massacre_frame.clear_content()
 
     def stop(self):
         """Shutdown the controller"""


### PR DESCRIPTION
Gets rid of the last mission when it is turned in. Fixes https://github.com/lunarplasma/EDMC-CombatTracker/issues/22